### PR TITLE
docs: Add database protection warning to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,28 @@ Key components:
 - **Auto-refresh** queries automatically refresh stale data (>5 min old)
 - **LaunchAgent** for always-on availability (macOS)
 
+---
+
+## ⚠️ DATABASE PROTECTION - READ THIS ⚠️
+
+**The database at `~/.claude/contrib/analytics/data.db` contains irreplaceable historical data.**
+
+### NEVER do any of the following:
+- Add code that deletes the database file (`os.remove()`, `unlink()`, `rm`)
+- Add `DROP TABLE` statements for `events`, `sessions`, `ingested_files`, or `git_commits`
+- Add `DELETE FROM` for user data tables (only `patterns` table can be cleared - it's re-computed)
+- Add any "reset" or "clear all" functionality that destroys historical data
+
+### Safe operations:
+- `DELETE FROM patterns` - OK, patterns are re-computed derived data
+- `make uninstall` - OK, preserves database (only removes LaunchAgent + MCP config)
+- `make reinstall` - OK, just reinstalls Python package
+
+### If you need to test destructive operations:
+Use a temporary database in tests (all tests already do this via `tmpdir`).
+
+---
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds prominent warning section to CLAUDE.md about database protection
- Documents that `~/.claude/contrib/analytics/data.db` contains irreplaceable historical data
- Lists forbidden operations (DROP TABLE, DELETE FROM user tables, file deletion)
- Lists safe operations (DELETE FROM patterns, make uninstall/reinstall)
- Notes that tests use temporary databases

## Test plan

- [x] Verified no existing code can drop the database
- [x] All 205 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)