### PR TITLE
feat: Add expand parameter to sample_sequences() (closes #73)

### DIFF
--- a/src/session_analytics/cli.py
+++ b/src/session_analytics/cli.py
@@ -990,6 +990,7 @@ def cmd_sample_sequences(args):
         count=args.limit,
         context_events=args.context,
         days=args.days,
+        expand=args.expand,
     )
     print(format_output(result, args.json))
 
@@ -1605,6 +1606,11 @@ Data location: ~/.claude/contrib/analytics/data.db
     sub.add_argument("--limit", type=int, default=5, help="Number of samples (default: 5)")
     sub.add_argument(
         "--context", type=int, default=2, help="Context events before/after (default: 2)"
+    )
+    sub.add_argument(
+        "--expand",
+        action="store_true",
+        help="Match expanded tool names (Bash→command, Skill→skill_name, Task→subagent_type)",
     )
     sub.set_defaults(func=cmd_sample_sequences)
 

--- a/src/session_analytics/guide.md
+++ b/src/session_analytics/guide.md
@@ -36,10 +36,17 @@ identify permission gaps.
 
 | Tool | Purpose |
 |------|---------|
-| `get_tool_sequences(days?, min_count?, length?, limit?)` | Common tool chains (e.g., Read → Edit → Bash) |
-| `sample_sequences(pattern, limit?, context_events?)` | Random samples of a pattern with surrounding context |
+| `get_tool_sequences(days?, min_count?, length?, limit?, expand?)` | Common tool chains (e.g., Read → Edit → Bash) |
+| `sample_sequences(pattern, limit?, context_events?, expand?)` | Random samples of a pattern with surrounding context |
 | `get_permission_gaps(days?, min_count?)` | Commands not covered by settings.json (supports glob patterns) |
 | `get_insights(days?, refresh?)` | Pre-computed patterns for /improve-workflow |
+
+**expand**: When `True`, expands tool names to specific variants:
+- Bash → specific command (e.g., "git", "make")
+- Skill → skill name (e.g., "commit", "pr-review")
+- Task → subagent type (e.g., "Explore", "Plan")
+
+Use `get_tool_sequences(expand=True)` to discover expanded patterns, then `sample_sequences(pattern, expand=True)` to get examples.
 
 ### Failure Analysis
 

--- a/src/session_analytics/server.py
+++ b/src/session_analytics/server.py
@@ -247,7 +247,13 @@ def get_tool_sequences(
 
 
 @mcp.tool()
-def sample_sequences(pattern: str, limit: int = 5, context_events: int = 2, days: int = 7) -> dict:
+def sample_sequences(
+    pattern: str,
+    limit: int = 5,
+    context_events: int = 2,
+    days: int = 7,
+    expand: bool = False,
+) -> dict:
     """Get random samples of a sequence pattern with surrounding context.
 
     Instead of just counting "Read → Edit" occurrences, returns actual examples
@@ -258,15 +264,21 @@ def sample_sequences(pattern: str, limit: int = 5, context_events: int = 2, days
         limit: Number of random samples to return (default: 5)
         context_events: Number of events before/after to include (default: 2)
         days: Number of days to analyze (default: 7)
+        expand: If True, match expanded tool names (Bash→command, Skill→skill_name,
+                Task→subagent_type). Use with patterns from get_tool_sequences(expand=True).
 
     Returns:
         Pattern info, total occurrences, and sampled instances with context
     """
     queries.ensure_fresh_data(storage, days=days)
-    result = patterns.sample_sequences(
-        storage, pattern=pattern, count=limit, context_events=context_events, days=days
+    return patterns.sample_sequences(
+        storage,
+        pattern=pattern,
+        count=limit,
+        context_events=context_events,
+        days=days,
+        expand=expand,
     )
-    return {"status": "ok", **result}
 
 
 @mcp.tool()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -504,6 +504,7 @@ class TestCliCommands:
             limit = 5
             context = 2
             days = 7
+            expand = False
 
         with patch("session_analytics.cli.SQLiteStorage", return_value=populated_storage):
             cmd_sample_sequences(Args())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -151,6 +151,21 @@ def test_sample_sequences():
     assert "total_occurrences" in result
     assert "samples" in result
     assert isinstance(result["samples"], list)
+    assert "expanded" in result
+    assert result["expanded"] is False
+
+
+def test_sample_sequences_expand():
+    """Test that sample_sequences respects expand parameter."""
+    # Test with expand=True - should return expanded field set to True
+    result = sample_sequences.fn(
+        pattern="git → Edit", limit=5, context_events=2, days=7, expand=True
+    )
+    assert result["status"] == "ok"
+    assert result["expanded"] is True
+    # Pattern may or may not match, but structure should be correct
+    assert "parsed_tools" in result
+    assert result["parsed_tools"] == ["git", "Edit"]
 
 
 def test_get_session_messages():


### PR DESCRIPTION
## Summary
- Adds `expand` parameter to `sample_sequences()` so users can match patterns like `"git → Edit"` instead of just `"Bash → Edit"`
- Extracts `_get_effective_name()` to shared module-level helper with debug logging for JSON parse failures
- Adds behavioral tests verifying actual matching behavior (not just response structure)

## Test plan
- [x] All 383 tests pass (`make check`)
- [x] Verified `expand=True` matches Bash commands
- [x] Verified `expand=True` matches Skill names
- [x] Verified `expand=True` matches Task subagent_type
- [x] Verified hyphenated skill names (e.g., "pr-review") are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)