### PR TITLE
feat: Add Linux systemd support for service installation

### DIFF
--- a/scripts/claude-session-analytics.service
+++ b/scripts/claude-session-analytics.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Claude Session Analytics - MCP server for session log analysis
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=__PROJECT_DIR__
+Environment=PYTHONPATH=__PROJECT_DIR__/src
+ExecStart=__VENV_PYTHON__ -m session_analytics.server
+Restart=always
+RestartSec=5
+StandardOutput=append:__HOME__/.claude/session-analytics.log
+StandardError=append:__HOME__/.claude/session-analytics.err
+
+[Install]
+WantedBy=default.target

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Install the session analytics server as a Linux systemd user service (auto-starts on login)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+VENV_PYTHON="$PROJECT_DIR/.venv/bin/python"
+SERVICE_TEMPLATE="$SCRIPT_DIR/claude-session-analytics.service"
+SERVICE_DIR="$HOME/.config/systemd/user"
+SERVICE_DEST="$SERVICE_DIR/claude-session-analytics.service"
+SERVICE_NAME="claude-session-analytics"
+
+# Check venv exists
+if [[ ! -f "$VENV_PYTHON" ]]; then
+    echo "Error: Virtual environment not found at $PROJECT_DIR/.venv"
+    echo "Run: python3 -m venv .venv && source .venv/bin/activate && pip install -e ."
+    exit 1
+fi
+
+# Create directories if needed
+mkdir -p "$SERVICE_DIR"
+mkdir -p "$HOME/.claude/contrib/analytics"
+
+# Stop existing service if running
+if systemctl --user is-active "$SERVICE_NAME" &>/dev/null; then
+    echo "Stopping existing service..."
+    systemctl --user stop "$SERVICE_NAME"
+fi
+
+# Generate service file with correct paths
+echo "Installing systemd service..."
+sed -e "s|__VENV_PYTHON__|$VENV_PYTHON|g" \
+    -e "s|__PROJECT_DIR__|$PROJECT_DIR|g" \
+    -e "s|__HOME__|$HOME|g" \
+    "$SERVICE_TEMPLATE" > "$SERVICE_DEST"
+
+# Reload systemd and start service
+systemctl --user daemon-reload
+echo "Starting service..."
+systemctl --user enable --now "$SERVICE_NAME"
+
+# Verify it's running
+sleep 1
+if systemctl --user is-active "$SERVICE_NAME" &>/dev/null; then
+    echo ""
+    echo "Session analytics installed and running!"
+    echo "  Logs: ~/.claude/session-analytics.log"
+    echo "  Errors: ~/.claude/session-analytics.err"
+    echo "  Status: systemctl --user status $SERVICE_NAME"
+    echo ""
+
+    # Also install CLI for use in hooks/scripts
+    echo "Installing CLI..."
+    "$SCRIPT_DIR/install-cli.sh"
+    echo ""
+    echo "To uninstall: $SCRIPT_DIR/uninstall-systemd.sh"
+else
+    echo "Error: Service failed to start. Check logs:"
+    echo "  journalctl --user -u $SERVICE_NAME"
+    echo "  ~/.claude/session-analytics.err"
+    exit 1
+fi

--- a/scripts/uninstall-systemd.sh
+++ b/scripts/uninstall-systemd.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Uninstall the session analytics systemd user service (preserves database)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVICE_DEST="$HOME/.config/systemd/user/claude-session-analytics.service"
+SERVICE_NAME="claude-session-analytics"
+
+# Stop and disable service if running
+if systemctl --user is-active "$SERVICE_NAME" &>/dev/null; then
+    echo "Stopping service..."
+    systemctl --user stop "$SERVICE_NAME"
+fi
+
+if systemctl --user is-enabled "$SERVICE_NAME" &>/dev/null; then
+    echo "Disabling service..."
+    systemctl --user disable "$SERVICE_NAME"
+fi
+
+# Remove service file
+if [[ -f "$SERVICE_DEST" ]]; then
+    echo "Removing service file..."
+    rm "$SERVICE_DEST"
+    systemctl --user daemon-reload
+fi
+
+# Uninstall CLI
+"$SCRIPT_DIR/uninstall-cli.sh"
+
+echo ""
+echo "Session analytics uninstalled."
+echo "Note: Database preserved at ~/.claude/contrib/analytics/data.db"


### PR DESCRIPTION
## Summary
- Ports cross-platform service management from claude-event-bus
- On Linux, `make install` now works via systemd user services instead of failing with `launchctl: command not found`

## Changes

**New files:**
- `scripts/claude-session-analytics.service` - systemd unit template
- `scripts/install-systemd.sh` - install user service  
- `scripts/uninstall-systemd.sh` - uninstall user service

**Makefile updates:**
- `install` / `uninstall` / `restart` now detect OS via `uname`
- macOS → LaunchAgent (unchanged)
- Linux → systemd user service (new)

## Test plan
- [x] `make check` passes
- [ ] Test `make install` on Linux (systemd user service)
- [ ] Test `make restart` on Linux
- [ ] Test `make uninstall` on Linux

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)