### PR TITLE
feat: Add Tailscale authentication middleware

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Pytest configuration and shared fixtures."""
 
+import os
 import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -7,6 +8,12 @@ from pathlib import Path
 import pytest
 
 from session_analytics.storage import Event, Session, SQLiteStorage
+
+
+def pytest_configure(config):
+    """Set up test environment before any imports happen."""
+    # Disable Tailscale auth for tests
+    os.environ["SESSION_ANALYTICS_AUTH_DISABLED"] = "1"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
Port `TailscaleAuthMiddleware` from claude-event-bus for consistent security across MCP servers in multi-machine setups.

## Changes
- Add `TailscaleAuthMiddleware` class to `server.py`
- Update `create_app()` to wrap app with auth middleware
- Add `pytest_configure` hook to disable auth in tests
- Add 3 middleware tests (with header, without header, non-HTTP passthrough)

## Configuration
- Auth **enabled by default** (requires `tailscale serve` proxy)
- Set `SESSION_ANALYTICS_AUTH_DISABLED=1` to disable for local dev/testing

## Test plan
- [x] `make check` passes (384 tests)
- [x] Middleware tests cover: valid header → 200, missing header → 401, non-HTTP → passthrough
- [ ] Manual test with `tailscale serve --bg 8081` on server
- [ ] Verify client connections via HTTPS URL work

## Next steps (after merge)
1. Run `tailscale serve --bg 8081` on speck-vm
2. Update client MCP configs to `https://speck-vm.tailac7b3c.ts.net:8081/mcp`

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)